### PR TITLE
fix: security issues in bridge communication

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,28 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
 # whatspurr
 
 A grammY-style TypeScript library for WhatsApp, powered by whatsmeow (Go) via a WebSocket sidecar.
+
+## Commands
+
+```bash
+# TypeScript
+bun run build          # tsc -p tsconfig.build.json → dist/
+bun run typecheck      # type-check without emit
+bun run lint           # biome check .
+bun run lint:fix       # biome check --fix .
+bun run format         # biome format --write .
+bun test               # run all tests
+bun test <file>        # run a single test file
+
+# Go sidecar
+bun run build:go                                      # build for local dev → bin/bridge
+cd go && go build -o ../bin/bridge                    # raw build
+GOOS=linux GOARCH=amd64 go build -o ../bin/bridge-linux-amd64  # cross-compile
+```
 
 ## Architecture
 
@@ -9,32 +31,29 @@ A grammY-style TypeScript library for WhatsApp, powered by whatsmeow (Go) via a 
 - **Transport**: JSON messages over WebSocket on `127.0.0.1` (random port, single-client mode, auth token)
 - **Distribution**: Contributors build Go locally. End users get prebuilt binaries via postinstall.
 
-## Runtime
+## Bridge Protocol
 
-Default to using Bun instead of Node.js.
+Startup sequence:
+1. TS spawns the Go binary with `--session-dir`, `--db-name`, `--download-dir`, etc. Auth token is passed via `BRIDGE_TOKEN` env var (not a CLI flag — avoids leaking it in `ps`).
+2. Go prints `ready 127.0.0.1:PORT` to stdout when ready.
+3. TS reads stdout, extracts address, opens a WebSocket connection using the token as a subprotocol (`bridge-auth-<token>`) instead of a query parameter.
 
-- Use `bun <file>` instead of `node <file>` or `ts-node <file>`
-- Use `bun test` instead of `jest` or `vitest`
-- Use `bun install` instead of `npm install` or `yarn install` or `pnpm install`
-- Use `bun run <script>` instead of `npm run <script>` or `yarn run <script>` or `pnpm run <script>`
-- Bun automatically loads .env, so don't use dotenv.
+Wire format (all JSON):
+```
+Command:  {"id": "uuid", "session": "name", "method": "send_message", "params": {...}}
+Response: {"id": "uuid", "result": {...}} or {"id": "uuid", "error": {"code": N, "message": "..."}}
+Event:    {"type": "event", "session": "name", "event": "message", "data": {...}}
+```
 
-## TS Guidelines
+Commands time out after 30s. The bridge allows a maximum of 64 concurrent commands (goroutine pool). Sessions persist via SQLite; name→JID mapping is stored in `sessionDir/sessions.json`.
 
-- Native `WebSocket` (works in both Bun and Node 21+). Don't use `ws`.
-- `child_process.spawn` for launching the Go binary (cross-runtime compatible).
-- Library code in `src/` must work on both Bun and Node.js. Don't use Bun-specific APIs (`Bun.file`, `bun:sqlite`, etc.) in library code.
-- Scripts in `scripts/` can use Bun APIs freely.
-- Use `bun test` with `import { test, expect } from "bun:test"` for tests.
+## Key Data Flows
 
-## Go Guidelines
+**Sending a message**: `ctx.reply()` → `Api.sendMessage()` → `bridge.send("send_message", params, session)` → Go `commands.go` → `whatsmeow.Client.SendMessage()`
 
-- Go source lives in `go/`.
-- Use `modernc.org/sqlite` (pure Go SQLite, no CGo) for session storage.
-- Use `nhooyr.io/websocket` for the WS server.
-- Keep Go code minimal — it's a thin dispatch layer mapping JSON commands to whatsmeow API calls.
-- Build locally: `cd go && go build -o ../bin/bridge`
-- Cross-compile: `GOOS=linux GOARCH=amd64 go build -o ../bin/bridge-linux-amd64`
+**Receiving an event**: whatsmeow fires event → `handler.go` → `manager.sendEvent(session, type, data)` → WebSocket push → `bridge.ts` listener demux → `WhatsApp` emits to middleware stack → `Context` created → user handlers run
+
+**Multi-session**: `WhatsAppManager` creates a single `Bridge`, then creates `WhatsApp` instances that share it. All commands are tagged with a session name; all events carry a session name for demultiplexing.
 
 ## Project Structure
 
@@ -60,3 +79,40 @@ scripts/          Build & distribution scripts
   release.ts      Cross-compile for all platforms
 bin/              Compiled Go binary (gitignored)
 ```
+
+## Runtime
+
+Default to using Bun instead of Node.js.
+
+- Use `bun <file>` instead of `node <file>` or `ts-node <file>`
+- Use `bun test` instead of `jest` or `vitest`
+- Use `bun install` instead of `npm install` or `yarn install` or `pnpm install`
+- Use `bun run <script>` instead of `npm run <script>` or `yarn run <script>` or `pnpm run <script>`
+- Bun automatically loads .env, so don't use dotenv.
+
+## TS Guidelines
+
+- Native `WebSocket` (works in both Bun and Node 21+). Don't use `ws`.
+- `child_process.spawn` for launching the Go binary (cross-runtime compatible).
+- Library code in `src/` must work on both Bun and Node.js. Don't use Bun-specific APIs (`Bun.file`, `bun:sqlite`, etc.) in library code.
+- Scripts in `scripts/` can use Bun APIs freely.
+- Use `bun test` with `import { test, expect } from "bun:test"` for tests.
+- Two tsconfigs: `tsconfig.json` (dev, allows `.ts` imports) and `tsconfig.build.json` (emit, rewrites extensions for ESM compat).
+- Linter: Biome (not ESLint). Line width 120, 2-space indent.
+
+## Go Guidelines
+
+- Go source lives in `go/`.
+- Use `modernc.org/sqlite` (pure Go SQLite, no CGo) for session storage.
+- Use `nhooyr.io/websocket` for the WS server.
+- Keep Go code minimal — it's a thin dispatch layer mapping JSON commands to whatsmeow API calls.
+- Build locally: `cd go && go build -o ../bin/bridge`
+- Cross-compile: `GOOS=linux GOARCH=amd64 go build -o ../bin/bridge-linux-amd64`
+
+## Types Reference
+
+JID formats: `"1234567890@s.whatsapp.net"` (DM), `"120363xxx@g.us"` (group)
+
+Filter strings for `wa.on()`: `"message"`, `"message:text"`, `"message:image"`, `"message:video"`, `"message:audio"`, `"message:document"`, `"connected"`, `"disconnected"`, `"qr"`, `"message_reaction"`, `"receipt"`, `"presence"`, `"group_join"`, `"group_leave"`, `"group_update"` — or use constants from `filters`.
+
+`NarrowContext<C, FilterQuery>` provides type-narrowed context in middleware; this is what powers type-safe access to `ctx.message`, `ctx.text`, etc. after filtering.

--- a/docs/guide/architecture.md
+++ b/docs/guide/architecture.md
@@ -79,12 +79,12 @@ sequenceDiagram
 
     Bot->>Mgr: mgr.start()
     Mgr->>Bridge: bridge.start()
-    Bridge->>Go: spawn(binary, args)
+    Bridge->>Go: spawn(binary, args, env: BRIDGE_TOKEN)
     Go->>Go: Init shared SQLite store
     Go->>SM: NewSessionManager(container)
     Go->>Go: Start WS server on 127.0.0.1:random
     Go-->>Bridge: stdout: "ready 127.0.0.1:PORT"
-    Bridge->>Go: WebSocket connect
+    Bridge->>Go: WebSocket connect (subprotocol auth)
     Note over Go: No sessions started yet
 
     Bot->>Mgr: mgr.connect("bot1")
@@ -199,9 +199,9 @@ Events: `qr`, `connected`, `disconnected`, `message`, `message_reaction`, `recei
 
 - **Localhost only** — WS server binds to `127.0.0.1`, never exposed to the network
 - **Random port** — OS assigns an ephemeral port, communicated via stdout
-- **Auth token** — 64-byte random token required for WS connection
+- **Auth token** — 32-byte random token passed via `BRIDGE_TOKEN` env var (not a CLI flag); authenticated via `Sec-WebSocket-Protocol` subprotocol header, verified with constant-time compare
 - **Single WS connection** — only one client can connect at a time
 - **Bounded concurrency** — max 64 concurrent command handlers
-- **Size limits** — 140 MB WS read limit, per-type media caps (16 MB images, 100 MB documents)
-- **Input validation** — JID parsing, base64 pre-checks, DB name path traversal prevention
+- **Size limits** — 135 MB WS read limit, per-type media caps (16 MB images, 100 MB documents)
+- **Input validation** — JID parsing, base64 pre-checks, DB name path traversal prevention, `download_media` path confined to configured download directory
 - **Opaque errors** — generic errors to the client, detailed logs server-side only

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -62,13 +62,19 @@ process.on("SIGINT", async () => {
 
 whatspurr runs a Go sidecar process that handles the WhatsApp Web protocol via [whatsmeow](https://github.com/tulir/whatsmeow). Your TypeScript code communicates with it over a local WebSocket connection.
 
-```
-┌──────────────┐   WebSocket (localhost)   ┌──────────────┐
-│  Your TS Bot │ ◄──────────────────────►  │  Go Sidecar  │
-│              │    JSON commands/events   │  (whatsmeow) │
-└──────────────┘                           └──────────────┘
-                                                  │
-                                           WhatsApp Servers
+```mermaid
+flowchart LR
+    TS("🤖 Your TS Bot")
+    Go("⚙️ Go Sidecar\nwhatsmeow")
+    WA("💬 WhatsApp\nServers")
+
+    TS -->|"JSON commands"| Go
+    Go -->|"events"| TS
+    Go <-->|"WhatsApp Web protocol"| WA
+
+    style TS  fill:#3178c6,stroke:#235d9f,color:#fff,rx:8
+    style Go  fill:#00ADD8,stroke:#0090b8,color:#fff,rx:8
+    style WA  fill:#25d366,stroke:#128c7e,color:#fff,rx:8
 ```
 
 - The Go binary is started and managed automatically

--- a/examples/multi-session.ts
+++ b/examples/multi-session.ts
@@ -50,7 +50,11 @@ for (const [name, wa] of [
 ] as const) {
   wa.on("message:text", async (ctx) => {
     console.log(`[${name}] ${ctx.from}: ${ctx.text}`);
-    await new Promise((r) => setTimeout(r, 5000));
+    await new Promise((r) => setTimeout(r, 2000));
+    await ctx.markRead();
+    await new Promise((r) => setTimeout(r, 1000));
+    await ctx.sendTyping();
+    await new Promise((r) => setTimeout(r, 2000));
     await ctx.reply(`Echo: ${ctx.text}`);
   });
 }

--- a/go/commands.go
+++ b/go/commands.go
@@ -259,6 +259,19 @@ func (s *Session) cmdDownloadMedia(cmd Command) Response {
 		return Response{Error: &ErrorInfo{Code: 1003, Message: "missing 'path' parameter"}}
 	}
 
+	// Prevent path traversal: destPath must resolve within the allowed download directory
+	absBase, err := filepath.Abs(downloadDir)
+	if err != nil {
+		return Response{Error: &ErrorInfo{Code: 1009, Message: "server misconfiguration: invalid download dir"}}
+	}
+	absDest, err := filepath.Abs(destPath)
+	if err != nil {
+		return Response{Error: &ErrorInfo{Code: 1003, Message: "invalid path"}}
+	}
+	if !strings.HasPrefix(absDest+string(filepath.Separator), absBase+string(filepath.Separator)) {
+		return Response{Error: &ErrorInfo{Code: 1003, Message: "path outside allowed download directory"}}
+	}
+
 	parts := strings.SplitN(ref, ":", 2)
 	if len(parts) != 2 {
 		return Response{Error: &ErrorInfo{Code: 1003, Message: "invalid mediaRef format"}}

--- a/go/main.go
+++ b/go/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"crypto/subtle"
 	"flag"
 	"fmt"
 	"log"
@@ -27,22 +28,24 @@ var (
 	authToken         string
 	sessionDir        string
 	dbName            string
+	downloadDir       string
 	logLevel          string
 	autoPresence      bool
 	subscribeOutgoing bool
 )
 
 func main() {
-	flag.StringVar(&authToken, "token", "", "Auth token for WebSocket connections (required)")
 	flag.StringVar(&sessionDir, "session-dir", "./session", "Session data directory")
 	flag.StringVar(&dbName, "db-name", "whatspurr.db", "SQLite database filename")
+	flag.StringVar(&downloadDir, "download-dir", "./downloads", "Directory for downloaded media files")
 	flag.StringVar(&logLevel, "log-level", "info", "Log level: debug, info, warn, error")
 	flag.BoolVar(&autoPresence, "auto-presence", false, "Send available presence on connect")
 	flag.BoolVar(&subscribeOutgoing, "subscribe-outgoing", false, "Forward outgoing (sent by us) messages to TS")
 	flag.Parse()
 
+	authToken = os.Getenv("BRIDGE_TOKEN")
 	if authToken == "" {
-		log.Fatal("--token flag is required")
+		log.Fatal("BRIDGE_TOKEN environment variable is required")
 	}
 
 	bridgeLog = waLog.Stdout("Bridge", logLevel, true)
@@ -53,6 +56,10 @@ func main() {
 
 	if err := os.MkdirAll(sessionDir, 0700); err != nil {
 		log.Fatalf("Failed to create session dir: %v", err)
+	}
+
+	if err := os.MkdirAll(downloadDir, 0750); err != nil {
+		log.Fatalf("Failed to create download dir: %v", err)
 	}
 
 	// Init SQLite store — shared across all sessions
@@ -75,8 +82,11 @@ func main() {
 
 	// HTTP server for WebSocket upgrade
 	mux := http.NewServeMux()
+	expectedProto := "bridge-auth-" + authToken
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Query().Get("token") != authToken {
+		// Authenticate via WebSocket subprotocol (constant-time to avoid timing leaks)
+		proto := r.Header.Get("Sec-WebSocket-Protocol")
+		if subtle.ConstantTimeCompare([]byte(proto), []byte(expectedProto)) != 1 {
 			http.Error(w, "unauthorized", http.StatusUnauthorized)
 			return
 		}
@@ -89,7 +99,9 @@ func main() {
 			return
 		}
 
-		conn, err := websocket.Accept(w, r, &websocket.AcceptOptions{})
+		conn, err := websocket.Accept(w, r, &websocket.AcceptOptions{
+			Subprotocols: []string{expectedProto},
+		})
 		if err != nil {
 			manager.connMu.Unlock()
 			bridgeLog.Errorf("WebSocket accept error: %v", err)

--- a/go/session.go
+++ b/go/session.go
@@ -20,7 +20,7 @@ const (
 	maxConcurrentCommands = 64
 	wsReadTimeout         = 5 * time.Minute
 	wsWriteTimeout        = 30 * time.Second
-	wsReadLimit           = 140 * 1024 * 1024
+	wsReadLimit           = 135 * 1024 * 1024 // max doc (100MB) * ~1.34 base64 overhead
 )
 
 // Command is a request from TS to Go.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arnabxd/whatspurr",
-  "version": "0.1.0-beta-02",
+  "version": "0.1.0-beta-03",
   "description": "A grammY-style TypeScript library for WhatsApp, powered by whatsmeow (Go)",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -124,13 +124,15 @@ export class Bridge extends EventEmitter {
     const autoPresence = this.config.autoPresence !== false; // default true
     const subscribeOutgoing = this.config.subscribeOutgoing === true; // default false
 
+    const downloadDir = this.config.downloadDir ?? "./downloads";
+
     const args = [
-      "--token",
-      this.authToken,
       "--session-dir",
       sessionDir,
       "--db-name",
       dbName,
+      "--download-dir",
+      downloadDir,
       "--log-level",
       logLevel,
       ...(autoPresence ? ["--auto-presence"] : []),
@@ -139,6 +141,7 @@ export class Bridge extends EventEmitter {
 
     this.process = spawn(binaryPath, args, {
       stdio: ["ignore", "pipe", "pipe"],
+      env: { ...process.env, BRIDGE_TOKEN: this.authToken },
     });
 
     this.process.on("exit", (code, signal) => {
@@ -198,8 +201,8 @@ export class Bridge extends EventEmitter {
 
   private connectWs(): Promise<void> {
     return new Promise((resolve, reject) => {
-      const url = `ws://${this.listenAddr}/?token=${this.authToken}`;
-      this.ws = new WebSocket(url);
+      const url = `ws://${this.listenAddr}/`;
+      this.ws = new WebSocket(url, [`bridge-auth-${this.authToken}`]);
 
       this.ws.onopen = () => {
         this._ready = true;

--- a/src/whatsapp.ts
+++ b/src/whatsapp.ts
@@ -110,12 +110,14 @@ export class WhatsApp extends Composer<Context> {
   }
 
   private async handleEvent(eventData: EventData): Promise<void> {
+    if (!this.started) return;
     const ctx = new Context(eventData, this.api);
     const mw = this.middleware();
 
     try {
       await mw(ctx, async () => {});
     } catch (err) {
+      if (!this.started) return; // bridge shut down mid-handler; error is expected
       this.onError(err instanceof Error ? err : new Error(String(err)), ctx);
     }
   }


### PR DESCRIPTION
## Summary

Security hardening for the TS↔Go bridge connection, a graceful shutdown fix, docs improvements, and an updated example.

---

### Security fixes (`src/bridge.ts`, `go/main.go`, `go/session.go`, `go/commands.go`)

- **Token no longer in process args** — `BRIDGE_TOKEN` is now passed via environment variable instead of `--token` CLI flag, preventing it from leaking in `ps`/`/proc` listings
- **Token no longer in WS URL** — authentication moved from query param (`?token=...`) to `Sec-WebSocket-Protocol` subprotocol header, keeping the token out of HTTP access logs
- **Constant-time token comparison** — `crypto/subtle.ConstantTimeCompare` used to prevent timing side-channel leaks
- **Path traversal prevention** — `download_media` now validates that the destination path resolves within the configured download directory (`--download-dir`, default `./downloads`); arbitrary filesystem writes are rejected
- **WS read limit tightened** — reduced from 140 MB to 135 MB (tight cap above the actual maximum: 100 MB document × ~1.34 base64 overhead)

### Graceful shutdown fix (`src/whatsapp.ts`)

Middleware handlers in-flight during `stop()` would surface a noisy "Bridge is not connected" error via `onError`. Two guards added to `handleEvent`:
- Skip execution entirely if `started` is already `false` when the handler fires
- Suppress errors caught after `started` is set to `false` mid-await (e.g. `markRead` racing with shutdown)

### Docs (`docs/guide/getting-started.md`, `docs/guide/architecture.md`)

- Replaced ASCII architecture diagram with a styled Mermaid flowchart using GitHub language colors (TypeScript `#3178c6`, Go `#00ADD8`)
- Updated architecture security section to reflect the new token transport, constant-time compare, download path confinement, and corrected WS read limit

### Example (`examples/multi-session.ts`)

Added `markRead` and a typing indicator to the echo bot to better demonstrate real-world handler patterns.
