### PR TITLE
feat: add reply/quoted message detection

### DIFF
--- a/docs/guide/messaging.md
+++ b/docs/guide/messaging.md
@@ -16,6 +16,38 @@
 | `ctx.sendAudio(data, options?)` | No | Send audio |
 | `ctx.sendDocument(data, options?)` | No | Send a document |
 
+## Detecting Replies
+
+When an incoming message is a reply to another message, you can access the quoted message info:
+
+```ts
+wa.on("message", async (ctx) => {
+  if (ctx.isReply) {
+    const quoted = ctx.quotedMessage!;
+    console.log(`Reply to message ${quoted.messageId} from ${quoted.sender}`);
+
+    // Narrow by type
+    if (quoted.type === "text") {
+      console.log(`Quoted text: ${quoted.text}`);
+    } else if (quoted.type === "image") {
+      console.log(`Quoted image (${quoted.mimetype})`);
+    }
+  }
+});
+```
+
+The `quotedMessage` is a discriminated union on the `type` field:
+
+| Type | Interface | Fields |
+|------|-----------|--------|
+| `"text"` | `QuotedTextMessage` | `text` |
+| `"image"` `"video"` `"audio"` `"document"` `"sticker"` | `QuotedMediaMessage` | `mimetype`, `caption?`, `filename?` |
+| `"contact"` | `QuotedContactMessage` | `displayName` |
+| `"location"` | `QuotedLocationMessage` | `latitude`, `longitude` |
+| `undefined` | `QuotedUnknownMessage` | *(unrecognized message type)* |
+
+All quoted message types include `messageId` and `sender` (the JID of who sent the original message).
+
 ## Quoting a Specific Message
 
 By default, `ctx.reply*()` quotes the message that triggered the handler. You can quote any message by passing `quotedMessageId` explicitly:

--- a/examples/quoted-reply.ts
+++ b/examples/quoted-reply.ts
@@ -40,6 +40,12 @@ wa.on("message", async (ctx) => {
   console.log(`  Reply:  ${ctx.text ?? `[${ctx.message!.type}]`}\n`);
 
   await ctx.markRead();
+
+  // Echo back, quoting the same original message
+  await ctx.send(`Echo: ${ctx.text ?? `[${ctx.message!.type}]`}`, {
+    quotedMessageId: quoted.messageId,
+    quotedSender: quoted.sender,
+  });
 });
 
 // Reply to any "!quote" command with info about the quoted message

--- a/examples/quoted-reply.ts
+++ b/examples/quoted-reply.ts
@@ -1,0 +1,85 @@
+import { WhatsApp } from "../src/index.ts";
+import { renderUnicodeCompact } from "uqr";
+
+const wa = new WhatsApp({
+  sessionDir: "./session",
+  logLevel: "info",
+  sessionName: "account-2",
+});
+
+wa.on("qr", (ctx) => {
+  console.log("\nScan this QR:\n");
+  console.log(renderUnicodeCompact(ctx.qr!.code));
+});
+
+wa.on("connected", (ctx) => {
+  console.log(`Connected as ${ctx.connected!.jid}\n`);
+});
+
+// Log all replies with info about the quoted message
+wa.on("message", async (ctx) => {
+  if (!ctx.isReply) return;
+
+  const quoted = ctx.quotedMessage!;
+  let description = `[${quoted.type ?? "unknown"}]`;
+
+  if (quoted.type === "text") {
+    description = `"${quoted.text}"`;
+  } else if (quoted.type === "image" || quoted.type === "video") {
+    description = `[${quoted.type}${quoted.caption ? `: ${quoted.caption}` : ""}]`;
+  } else if (quoted.type === "contact") {
+    description = `[contact: ${quoted.displayName}]`;
+  } else if (quoted.type === "location") {
+    description = `[location: ${quoted.latitude}, ${quoted.longitude}]`;
+  }
+
+  console.log(
+    `${ctx.from} replied to ${quoted.sender}'s message (${quoted.messageId})`,
+  );
+  console.log(`  Quoted: ${description}`);
+  console.log(`  Reply:  ${ctx.text ?? `[${ctx.message!.type}]`}\n`);
+
+  await ctx.markRead();
+});
+
+// Reply to any "!quote" command with info about the quoted message
+wa.command("quote", async (ctx) => {
+  if (!ctx.isReply) {
+    await ctx.reply("Reply to a message with /quote to see its info.");
+    return;
+  }
+
+  const quoted = ctx.quotedMessage!;
+  const lines = [
+    `Message ID: ${quoted.messageId}`,
+    `Sender: ${quoted.sender}`,
+    `Type: ${quoted.type ?? "unknown"}`,
+  ];
+
+  if (quoted.type === "text") {
+    lines.push(`Text: ${quoted.text}`);
+  } else if (
+    quoted.type === "image" ||
+    quoted.type === "video" ||
+    quoted.type === "document"
+  ) {
+    lines.push(`MIME: ${quoted.mimetype}`);
+    if (quoted.caption) lines.push(`Caption: ${quoted.caption}`);
+    if (quoted.type === "document" && quoted.filename)
+      lines.push(`Filename: ${quoted.filename}`);
+  }
+
+  await ctx.reply(lines.join("\n"));
+});
+
+await wa.start();
+console.log(
+  "Listening for replies. Try replying to any message, or reply with /quote.",
+);
+console.log("Press Ctrl+C to stop.\n");
+
+process.on("SIGINT", async () => {
+  console.log("\nShutting down...");
+  await wa.stop();
+  process.exit(0);
+});

--- a/go/handler.go
+++ b/go/handler.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"fmt"
 
+	"go.mau.fi/whatsmeow/proto/waE2E"
 	"go.mau.fi/whatsmeow/types"
 	"go.mau.fi/whatsmeow/types/events"
 	"google.golang.org/protobuf/proto"
@@ -146,6 +147,61 @@ func (s *Session) handleWhatsmeowEvent(evt interface{}) {
 	}
 }
 
+func extractQuotedInfo(ci *waE2E.ContextInfo, fallbackSender string) map[string]interface{} {
+	if ci == nil || ci.StanzaID == nil {
+		return nil
+	}
+
+	sender := ci.GetParticipant()
+	if sender == "" {
+		sender = fallbackSender
+	}
+
+	quoted := map[string]interface{}{
+		"messageId": ci.GetStanzaID(),
+		"sender":    sender,
+	}
+
+	if qm := ci.GetQuotedMessage(); qm != nil {
+		switch {
+		case qm.GetConversation() != "":
+			quoted["type"] = "text"
+			quoted["text"] = qm.GetConversation()
+		case qm.GetExtendedTextMessage() != nil:
+			quoted["type"] = "text"
+			quoted["text"] = qm.GetExtendedTextMessage().GetText()
+		case qm.GetImageMessage() != nil:
+			quoted["type"] = "image"
+			quoted["caption"] = qm.GetImageMessage().GetCaption()
+			quoted["mimetype"] = qm.GetImageMessage().GetMimetype()
+		case qm.GetVideoMessage() != nil:
+			quoted["type"] = "video"
+			quoted["caption"] = qm.GetVideoMessage().GetCaption()
+			quoted["mimetype"] = qm.GetVideoMessage().GetMimetype()
+		case qm.GetAudioMessage() != nil:
+			quoted["type"] = "audio"
+			quoted["mimetype"] = qm.GetAudioMessage().GetMimetype()
+		case qm.GetDocumentMessage() != nil:
+			quoted["type"] = "document"
+			quoted["caption"] = qm.GetDocumentMessage().GetCaption()
+			quoted["mimetype"] = qm.GetDocumentMessage().GetMimetype()
+			quoted["filename"] = qm.GetDocumentMessage().GetFileName()
+		case qm.GetStickerMessage() != nil:
+			quoted["type"] = "sticker"
+			quoted["mimetype"] = qm.GetStickerMessage().GetMimetype()
+		case qm.GetContactMessage() != nil:
+			quoted["type"] = "contact"
+			quoted["displayName"] = qm.GetContactMessage().GetDisplayName()
+		case qm.GetLocationMessage() != nil:
+			quoted["type"] = "location"
+			quoted["latitude"] = qm.GetLocationMessage().GetDegreesLatitude()
+			quoted["longitude"] = qm.GetLocationMessage().GetDegreesLongitude()
+		}
+	}
+
+	return quoted
+}
+
 func (s *Session) handleMessageEvent(v *events.Message) {
 	if v.Info.IsFromMe && !subscribeOutgoing {
 		return
@@ -176,6 +232,13 @@ func (s *Session) handleMessageEvent(v *events.Message) {
 		return
 	}
 
+	// Helper to attach quoted message info from ContextInfo
+	attachQuoted := func(ci *waE2E.ContextInfo) {
+		if q := extractQuotedInfo(ci, v.Info.Chat.String()); q != nil {
+			base["quotedMessage"] = q
+		}
+	}
+
 	switch {
 	case msg.GetConversation() != "":
 		base["type"] = "text"
@@ -184,6 +247,7 @@ func (s *Session) handleMessageEvent(v *events.Message) {
 	case msg.GetExtendedTextMessage() != nil:
 		base["type"] = "text"
 		base["text"] = msg.GetExtendedTextMessage().GetText()
+		attachQuoted(msg.GetExtendedTextMessage().GetContextInfo())
 
 	case msg.GetImageMessage() != nil:
 		im := msg.GetImageMessage()
@@ -200,6 +264,7 @@ func (s *Session) handleMessageEvent(v *events.Message) {
 		if im.GetHeight() > 0 {
 			base["height"] = im.GetHeight()
 		}
+		attachQuoted(im.GetContextInfo())
 
 	case msg.GetVideoMessage() != nil:
 		vm := msg.GetVideoMessage()
@@ -216,12 +281,14 @@ func (s *Session) handleMessageEvent(v *events.Message) {
 		if vm.GetHeight() > 0 {
 			base["height"] = vm.GetHeight()
 		}
+		attachQuoted(vm.GetContextInfo())
 
 	case msg.GetAudioMessage() != nil:
 		am := msg.GetAudioMessage()
 		base["type"] = "audio"
 		base["mimetype"] = am.GetMimetype()
 		base["mediaRef"] = encodeMediaRef("audio", am)
+		attachQuoted(am.GetContextInfo())
 
 	case msg.GetDocumentMessage() != nil:
 		dm := msg.GetDocumentMessage()
@@ -230,18 +297,21 @@ func (s *Session) handleMessageEvent(v *events.Message) {
 		base["mimetype"] = dm.GetMimetype()
 		base["filename"] = dm.GetFileName()
 		base["mediaRef"] = encodeMediaRef("document", dm)
+		attachQuoted(dm.GetContextInfo())
 
 	case msg.GetStickerMessage() != nil:
 		sm := msg.GetStickerMessage()
 		base["type"] = "sticker"
 		base["mimetype"] = sm.GetMimetype()
 		base["mediaRef"] = encodeMediaRef("sticker", sm)
+		attachQuoted(sm.GetContextInfo())
 
 	case msg.GetContactMessage() != nil:
 		cm := msg.GetContactMessage()
 		base["type"] = "contact"
 		base["displayName"] = cm.GetDisplayName()
 		base["vcard"] = cm.GetVcard()
+		attachQuoted(cm.GetContextInfo())
 
 	case msg.GetLocationMessage() != nil:
 		lm := msg.GetLocationMessage()
@@ -250,6 +320,7 @@ func (s *Session) handleMessageEvent(v *events.Message) {
 		base["longitude"] = lm.GetDegreesLongitude()
 		base["name"] = lm.GetName()
 		base["address"] = lm.GetAddress()
+		attachQuoted(lm.GetContextInfo())
 
 	default:
 		return

--- a/src/context.ts
+++ b/src/context.ts
@@ -12,6 +12,7 @@ import type {
   Message,
   PresenceEvent,
   QrEvent,
+  QuotedMessage,
   QuoteOptions,
   ReactionEvent,
   ReceiptEvent,
@@ -77,6 +78,16 @@ export class Context {
   /** Whether this message was sent by us (outgoing) */
   get isFromMe(): boolean {
     return this.message?.isFromMe ?? false;
+  }
+
+  /** Whether this message is a reply to another message */
+  get isReply(): boolean {
+    return this.message?.quotedMessage != null;
+  }
+
+  /** The quoted message info if this message is a reply, undefined otherwise */
+  get quotedMessage(): QuotedMessage | undefined {
+    return this.message?.quotedMessage;
   }
 
   /** QR event data (only on "qr" events) */

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ export { WhatsAppManager } from "./manager.ts";
 // Types
 export type {
   ConnectedEvent,
+  ContactContent,
   ContactMessage,
   DisconnectedEvent,
   DownloadResult,
@@ -26,7 +27,9 @@ export type {
   GroupUpdateEvent,
   // JID
   JID,
+  LocationContent,
   LocationMessage,
+  MediaContent,
   MediaMessage,
   MediaSendOptions,
   Message,
@@ -39,6 +42,14 @@ export type {
   NextFn,
   PresenceEvent,
   QrEvent,
+  // Quoted message
+  QuotedContactMessage,
+  QuotedLocationMessage,
+  QuotedMediaMessage,
+  QuotedMessage,
+  QuotedMessageBase,
+  QuotedTextMessage,
+  QuotedUnknownMessage,
   // Quote options
   QuoteOptions,
   ReactionEvent,
@@ -47,6 +58,7 @@ export type {
   SendOptions,
   SendResult,
   SessionInfo,
+  TextContent,
   TextMessage,
   // Config
   WhatsAppConfig,

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,6 +29,53 @@ export interface WhatsAppConfig {
 // ── Messages ─────────────────────────────────────────────────────────────────
 export type MessageType = "text" | "image" | "video" | "audio" | "document" | "sticker" | "contact" | "location";
 
+// ── Content shapes (shared by messages and quoted messages) ─────────────────
+export interface TextContent {
+  type: "text";
+  text: string;
+}
+
+export interface MediaContent {
+  type: "image" | "video" | "audio" | "document" | "sticker";
+  caption?: string;
+  mimetype: string;
+  filename?: string;
+}
+
+export interface ContactContent {
+  type: "contact";
+  displayName: string;
+}
+
+export interface LocationContent {
+  type: "location";
+  latitude: number;
+  longitude: number;
+}
+
+// ── Quoted messages ─────────────────────────────────────────────────────────
+export interface QuotedMessageBase {
+  messageId: string;
+  sender: JID;
+}
+
+export interface QuotedTextMessage extends QuotedMessageBase, TextContent {}
+export interface QuotedMediaMessage extends QuotedMessageBase, MediaContent {}
+export interface QuotedContactMessage extends QuotedMessageBase, ContactContent {}
+export interface QuotedLocationMessage extends QuotedMessageBase, LocationContent {}
+
+export interface QuotedUnknownMessage extends QuotedMessageBase {
+  type?: undefined;
+}
+
+export type QuotedMessage =
+  | QuotedTextMessage
+  | QuotedMediaMessage
+  | QuotedContactMessage
+  | QuotedLocationMessage
+  | QuotedUnknownMessage;
+
+// ── Messages ────────────────────────────────────────────────────────────────
 export interface MessageInfo {
   id: string;
   from: JID;
@@ -37,18 +84,13 @@ export interface MessageInfo {
   timestamp: number;
   isGroup: boolean;
   isFromMe: boolean;
+  /** Present when this message is a reply to another message */
+  quotedMessage?: QuotedMessage;
 }
 
-export interface TextMessage extends MessageInfo {
-  type: "text";
-  text: string;
-}
+export interface TextMessage extends MessageInfo, TextContent {}
 
-export interface MediaMessage extends MessageInfo {
-  type: "image" | "video" | "audio" | "document" | "sticker";
-  caption?: string;
-  mimetype: string;
-  filename?: string;
+export interface MediaMessage extends MessageInfo, MediaContent {
   /** Opaque ref used to download media via bridge */
   mediaRef: string;
   /** Whether this is a view-once media message */
@@ -59,16 +101,11 @@ export interface MediaMessage extends MessageInfo {
   height?: number;
 }
 
-export interface ContactMessage extends MessageInfo {
-  type: "contact";
-  displayName: string;
+export interface ContactMessage extends MessageInfo, ContactContent {
   vcard: string;
 }
 
-export interface LocationMessage extends MessageInfo {
-  type: "location";
-  latitude: number;
-  longitude: number;
+export interface LocationMessage extends MessageInfo, LocationContent {
   name?: string;
   address?: string;
 }


### PR DESCRIPTION
## Summary
- Extract quoted message info from whatsmeow's `ContextInfo` on the Go side for all message types (text, image, video, audio, document, sticker, contact, location)
- Expose `QuotedMessage` as a discriminated union type on the TS side, with shared content interfaces (`TextContent`, `MediaContent`, `ContactContent`, `LocationContent`) to avoid duplication between message and quoted message types
- Add `ctx.isReply` and `ctx.quotedMessage` getters to `Context`
- Fall back to chat JID when `Participant` is empty (fixes empty `sender` in DMs)
- Add "Detecting Replies" section to messaging docs

## Test plan
- [x] Receive a text reply in DM — verify `ctx.isReply` is `true` and `ctx.quotedMessage` has correct `sender`, `messageId`, and `type`
- [x] Receive a text reply in a group — verify `sender` is populated from `Participant`
- [x] Receive a reply to an image/video/audio/document/sticker/contact/location — verify correct `type` narrowing
- [x] Receive a reply to an unrecognized message type — verify `QuotedUnknownMessage` with `type: undefined`
- [x] Receive a non-reply message — verify `ctx.isReply` is `false` and `ctx.quotedMessage` is `undefined`
- [x] Send a quoted reply via `ctx.reply()` — verify it still works as before