### PR TITLE
feat: add edit and delete message support

### DIFF
--- a/examples/edit-delete.ts
+++ b/examples/edit-delete.ts
@@ -1,0 +1,66 @@
+import { WhatsApp } from "../src/index.ts";
+import { renderUnicodeCompact } from "uqr";
+
+const wa = new WhatsApp({
+  sessionDir: "./session",
+  logLevel: "info",
+  sessionName: "account-2",
+});
+
+wa.on("qr", (ctx) => {
+  console.log("\nScan this QR:\n");
+  console.log(renderUnicodeCompact(ctx.qr!.code));
+});
+
+wa.on("connected", (ctx) => {
+  console.log(`Connected as ${ctx.connected!.jid}\n`);
+});
+
+// !edit <new text> — reply to a bot message to edit it
+wa.command("edit", async (ctx) => {
+  if (!ctx.isReply) {
+    await ctx.reply("Reply to one of my messages with !edit <new text>");
+    return;
+  }
+
+  const newText = ctx.commandArgs?.trim();
+  if (!newText) {
+    await ctx.reply("Usage: !edit <new text>");
+    return;
+  }
+
+  const quoted = ctx.quotedMessage!;
+  await ctx.editMessage(quoted.messageId, newText);
+  console.log(`Edited message ${quoted.messageId} to: ${newText}`);
+});
+
+// !delete — reply to a bot message to delete it for everyone
+wa.command("delete", async (ctx) => {
+  if (!ctx.isReply) {
+    await ctx.reply("Reply to one of my messages with !delete");
+    return;
+  }
+
+  const quoted = ctx.quotedMessage!;
+  await ctx.deleteMessage(quoted.messageId);
+  console.log(`Deleted message ${quoted.messageId}`);
+});
+
+// !test — sends a message you can then edit or delete
+wa.command("test", async (ctx) => {
+  const result = await ctx.reply("This is a test message. Reply to it with !edit or !delete.");
+  console.log(`Sent test message: ${result.messageId}`);
+});
+
+await wa.start();
+console.log("Commands:");
+console.log("  !test    — send a test message");
+console.log("  !edit    — reply to a bot message with new text");
+console.log("  !delete  — reply to a bot message to delete it");
+console.log("\nPress Ctrl+C to stop.\n");
+
+process.on("SIGINT", async () => {
+  console.log("\nShutting down...");
+  await wa.stop();
+  process.exit(0);
+});

--- a/go/commands.go
+++ b/go/commands.go
@@ -33,6 +33,8 @@ func (s *Session) buildCommandHandlers() map[string]commandHandler {
 		"set_presence":       s.cmdSetPresence,
 		"set_status_message": s.cmdSetStatusMessage,
 		"get_status_privacy": s.cmdGetStatusPrivacy,
+		"edit_message":       s.cmdEditMessage,
+		"delete_message":     s.cmdDeleteMessage,
 	}
 }
 
@@ -534,4 +536,63 @@ func (s *Session) cmdGetStatusPrivacy(cmd Command) Response {
 	}
 
 	return Response{Result: map[string]interface{}{"privacy": entries}}
+}
+
+func (s *Session) cmdEditMessage(cmd Command) Response {
+	chat, err := s.parseJID(cmd.Params, "chat")
+	if err != nil {
+		return Response{Error: &ErrorInfo{Code: 1003, Message: err.Error()}}
+	}
+
+	messageId, _ := cmd.Params["messageId"].(string)
+	if messageId == "" {
+		return Response{Error: &ErrorInfo{Code: 1003, Message: "missing 'messageId' parameter"}}
+	}
+
+	newText, _ := cmd.Params["text"].(string)
+	if newText == "" {
+		return Response{Error: &ErrorInfo{Code: 1003, Message: "missing 'text' parameter"}}
+	}
+
+	newContent := &waE2E.Message{
+		Conversation: proto.String(newText),
+	}
+	editMsg := s.client.BuildEdit(chat, types.MessageID(messageId), newContent)
+
+	bridgeLog.Debugf("[%s] edit_message chat=%s id=%s", s.name, chat.String(), messageId)
+	resp, err := s.client.SendMessage(context.Background(), chat, editMsg)
+	if err != nil {
+		bridgeLog.Errorf("[%s] edit_message error: %v", s.name, err)
+		return Response{Error: &ErrorInfo{Code: 1004, Message: "edit failed"}}
+	}
+
+	return Response{Result: map[string]interface{}{
+		"messageId": resp.ID,
+	}}
+}
+
+func (s *Session) cmdDeleteMessage(cmd Command) Response {
+	chat, err := s.parseJID(cmd.Params, "chat")
+	if err != nil {
+		return Response{Error: &ErrorInfo{Code: 1003, Message: err.Error()}}
+	}
+
+	messageId, _ := cmd.Params["messageId"].(string)
+	if messageId == "" {
+		return Response{Error: &ErrorInfo{Code: 1003, Message: "missing 'messageId' parameter"}}
+	}
+
+	sender := s.client.Store.ID.ToNonAD()
+	revokeMsg := s.client.BuildRevoke(chat, sender, types.MessageID(messageId))
+
+	bridgeLog.Debugf("[%s] delete_message chat=%s id=%s", s.name, chat.String(), messageId)
+	resp, err := s.client.SendMessage(context.Background(), chat, revokeMsg)
+	if err != nil {
+		bridgeLog.Errorf("[%s] delete_message error: %v", s.name, err)
+		return Response{Error: &ErrorInfo{Code: 1004, Message: "delete failed"}}
+	}
+
+	return Response{Result: map[string]interface{}{
+		"messageId": resp.ID,
+	}}
 }

--- a/src/api.ts
+++ b/src/api.ts
@@ -143,6 +143,20 @@ export class Api {
     await this.send("set_presence", { type });
   }
 
+  // ── Edit / Delete ─────────────────────────────────────────────────────
+
+  /** Edit a previously sent text message */
+  async editMessage(chat: JID, messageId: string, newText: string): Promise<SendResult> {
+    const result = await this.send("edit_message", { chat, messageId, text: newText });
+    return { messageId: result.messageId as string };
+  }
+
+  /** Delete (revoke) a previously sent message ("delete for everyone") */
+  async deleteMessage(chat: JID, messageId: string): Promise<SendResult> {
+    const result = await this.send("delete_message", { chat, messageId });
+    return { messageId: result.messageId as string };
+  }
+
   // ── Status / Stories ────────────────────────────────────────────────────
 
   /** Set the "About" text status message */

--- a/src/context.ts
+++ b/src/context.ts
@@ -256,4 +256,18 @@ export class Context {
     if (!chat || !msgId) throw new Error("No message to react to");
     return this.api.sendReaction(chat, msgId, emoji);
   }
+
+  /** Edit a previously sent message in the current chat */
+  async editMessage(messageId: string, newText: string): Promise<SendResult> {
+    const chat = this.chat;
+    if (!chat) throw new Error("No chat to edit message in");
+    return this.api.editMessage(chat, messageId, newText);
+  }
+
+  /** Delete (revoke) a previously sent message in the current chat ("delete for everyone") */
+  async deleteMessage(messageId: string): Promise<SendResult> {
+    const chat = this.chat;
+    if (!chat) throw new Error("No chat to delete message in");
+    return this.api.deleteMessage(chat, messageId);
+  }
 }


### PR DESCRIPTION
## Summary
- Add `edit_message` and `delete_message` commands to the Go bridge using `BuildEdit`/`BuildRevoke` + `SendMessage`
- Add `editMessage()` and `deleteMessage()` methods to the TypeScript `Api` class
- Add `editMessage()` and `deleteMessage()` convenience methods on `Context`
- Add `examples/edit-delete.ts` demo script with `!test`, `!edit`, and `!delete` commands

## Test plan
- [x] Go builds clean
- [x] TypeScript typechecks clean
- [x] Biome lint passes
- [x] Run `bun run examples/edit-delete.ts`, send `!test`, then `!edit` and `!delete` against the bot's reply