### PR TITLE
fix: WebSocket keepalive ping and auto-reconnect

### DIFF
--- a/go/session.go
+++ b/go/session.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -158,6 +159,10 @@ func (m *SessionManager) serveConnected(conn *websocket.Conn) {
 				bridgeLog.Warnf("WS read error: %v", err)
 			}
 			return
+		}
+
+		if bytes.Contains(data, []byte(`"ping"`)) {
+			continue
 		}
 
 		var cmd Command

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arnabxd/whatspurr",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "A grammY-style TypeScript library for WhatsApp, powered by whatsmeow (Go)",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -12,6 +12,9 @@ const DEFAULT_BINARY_REPO = "ArnabXD/whatspurr";
 const STARTUP_TIMEOUT_MS = 10_000;
 const COMMAND_TIMEOUT_MS = 30_000;
 const LISTEN_ADDR_RE = /^127\.0\.0\.1:\d+$/;
+const WS_PING_INTERVAL_MS = 20_000;
+const WS_RECONNECT_BASE_MS = 1_000;
+const WS_RECONNECT_MAX_MS = 30_000;
 
 function getPlatformKey(): { goos: string; goarch: string; ext: string } {
   const os = platform();
@@ -98,6 +101,10 @@ export class Bridge extends EventEmitter {
   private authToken: string;
   private config: WhatsAppConfig;
   private _ready = false;
+  private _stopping = false;
+  private _pingInterval: ReturnType<typeof setInterval> | null = null;
+  private _reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private _reconnectDelay = WS_RECONNECT_BASE_MS;
 
   constructor(config: WhatsAppConfig = {}) {
     super();
@@ -206,6 +213,12 @@ export class Bridge extends EventEmitter {
 
       this.ws.onopen = () => {
         this._ready = true;
+        this._reconnectDelay = WS_RECONNECT_BASE_MS;
+        this._pingInterval = setInterval(() => {
+          if (this.ws?.readyState === WebSocket.OPEN) {
+            this.ws.send(JSON.stringify({ ping: true }));
+          }
+        }, WS_PING_INTERVAL_MS);
         resolve();
       };
 
@@ -218,13 +231,34 @@ export class Bridge extends EventEmitter {
 
       this.ws.onclose = () => {
         this._ready = false;
+        if (this._pingInterval) {
+          clearInterval(this._pingInterval);
+          this._pingInterval = null;
+        }
         this.emit("ws_close");
+        if (!this._stopping) {
+          this._scheduleReconnect();
+        }
       };
 
       this.ws.onmessage = (ev) => {
         this.handleMessage(ev.data as string);
       };
     });
+  }
+
+  private _scheduleReconnect(): void {
+    const delay = this._reconnectDelay;
+    this._reconnectDelay = Math.min(this._reconnectDelay * 2, WS_RECONNECT_MAX_MS);
+    this._reconnectTimer = setTimeout(async () => {
+      this._reconnectTimer = null;
+      if (this._stopping) return;
+      try {
+        await this.connectWs();
+      } catch {
+        // connectWs onclose will trigger another attempt if still not stopping
+      }
+    }, delay);
   }
 
   private handleMessage(raw: string): void {
@@ -235,6 +269,8 @@ export class Bridge extends EventEmitter {
       this.emit("error", new Error(`Invalid JSON from bridge: ${raw.slice(0, 200)}`));
       return;
     }
+
+    if ("pong" in msg) return;
 
     // Event push from Go
     if ("type" in msg && msg.type === "event") {
@@ -292,7 +328,17 @@ export class Bridge extends EventEmitter {
   }
 
   async stop(): Promise<void> {
+    this._stopping = true;
     this._ready = false;
+
+    if (this._reconnectTimer) {
+      clearTimeout(this._reconnectTimer);
+      this._reconnectTimer = null;
+    }
+    if (this._pingInterval) {
+      clearInterval(this._pingInterval);
+      this._pingInterval = null;
+    }
 
     // Reject all pending commands
     for (const [, { reject }] of this.pending) {

--- a/src/whatsapp.ts
+++ b/src/whatsapp.ts
@@ -13,6 +13,7 @@ export class WhatsApp extends Composer<Context> {
   private boundEventHandler: ((data: SessionEventData) => void) | null = null;
   private boundLogHandler: ((line: string) => void) | null = null;
   private boundExitHandler: ((info: { code: number | null; signal: string | null }) => void) | null = null;
+  private boundWsCloseHandler: (() => void) | null = null;
   private started = false;
 
   constructor(config?: WhatsAppConfig);
@@ -62,6 +63,9 @@ export class WhatsApp extends Composer<Context> {
 
       this.boundExitHandler = (info: { code: number | null; signal: string | null }) => this.onBridgeExit(info);
       this.bridge.on("exit", this.boundExitHandler);
+
+      this.boundWsCloseHandler = () => this.onWsClose();
+      this.bridge.on("ws_close", this.boundWsCloseHandler);
     }
 
     // Handle WhatsApp events from the bridge (filtered by session)
@@ -89,6 +93,10 @@ export class WhatsApp extends Composer<Context> {
     if (this.boundExitHandler) {
       this.bridge.off("exit", this.boundExitHandler);
       this.boundExitHandler = null;
+    }
+    if (this.boundWsCloseHandler) {
+      this.bridge.off("ws_close", this.boundWsCloseHandler);
+      this.boundWsCloseHandler = null;
     }
   }
 
@@ -126,6 +134,9 @@ export class WhatsApp extends Composer<Context> {
   protected onLog(line: string): void {
     console.log(`[bridge] ${line}`);
   }
+
+  /** Override to handle WebSocket disconnects (auto-reconnect is built-in; override for custom logic) */
+  protected onWsClose(): void {}
 
   /** Override to handle bridge process exit */
   protected onBridgeExit(info: { code: number | null; signal: string | null }): void {


### PR DESCRIPTION
## Summary

Fixes #12

- Sends a `{"ping":true}` frame every 20s to prevent NAT/OS idle timeouts from silently dropping the bridge WebSocket (Go's `wsReadTimeout` is 5 min)
- Auto-reconnects with exponential backoff (1s → 30s) on `ws_close`, gated on `_stopping` so intentional shutdowns don't loop
- Go side discards ping messages with a single `bytes.Contains` check (zero extra allocations, no double-unmarshal)
- Adds `WhatsApp.onWsClose()` override hook so consumers can observe disconnects

## Test plan

- [x] Start bot, leave idle for >5 min, verify events still arrive
- [ ] Kill/restart the Go bridge mid-session, verify TypeScript reconnects automatically
- [ ] Call `wa.stop()`, verify no reconnect loop fires
- [ ] Override `onWsClose()` in a subclass and confirm it is called on drop